### PR TITLE
refactor: add transaction request transformer

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,6 @@
     "@csfin/core": "^0.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "0.13.2",
-    "config": "^3.3.8",
     "express": "^4.18.2",
     "http-status-codes": "^2.2.0",
     "mariadb": "^3.0.2",
@@ -24,7 +23,6 @@
     "typeorm": "^0.3.11"
   },
   "devDependencies": {
-    "@types/config": "^3.3.0",
     "@types/express": "^4.17.15",
     "@types/validator": "^13.7.10",
     "ts-node": "^10.9.1"

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -1,9 +1,9 @@
-import config from "config";
-import { DataSource } from "typeorm";
+import { getDatabaseConfig } from "@csfin/core";
+import { DataSource, DataSourceOptions } from "typeorm";
 import { QuoteData, SecuritiesAccount, SecuritiesExchange, Security, Transaction } from "./entities";
 
 export const AppDataSource = new DataSource({
-  ...config.get("database"),
+  ...(getDatabaseConfig() as DataSourceOptions),
   synchronize: true,
   logging: false,
   entities: [QuoteData, SecuritiesAccount, SecuritiesExchange, Security, Transaction]

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,10 @@
 import "reflect-metadata";
 
-import config from "config";
 import express from "express";
 
+import { getExpressPort } from "@csfin/core";
 import { useContainer, useExpressServer } from "routing-controllers";
 import { Container } from "typedi";
-
 import {
   AccountController,
   QuoteDataController,
@@ -36,7 +35,7 @@ AppDataSource.initialize()
       ]
     });
 
-    const port: number = config.get("express.port");
+    const port = getExpressPort();
 
     app.listen(port, "0.0.0.0", () => {
       console.log(`Server listening on port ${port}`);

--- a/apps/dbinit/config/default.json
+++ b/apps/dbinit/config/default.json
@@ -1,5 +1,0 @@
-{
-  "api": {
-    "host": "http://localhost:4000"
-  }
-}

--- a/apps/dbinit/package.json
+++ b/apps/dbinit/package.json
@@ -11,12 +11,9 @@
   },
   "dependencies": {
     "@csfin/codi": "^0.0.1",
-    "@csfin/core": "^0.0.1",
-    "axios": "^1.2.1",
-    "config": "^3.3.8"
+    "@csfin/core": "^0.0.1"
   },
   "devDependencies": {
-    "@types/config": "^3.3.0",
     "ts-node": "^10.9.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,8 @@
     "lint:fix": "eslint --color --fix --ext .ts --ext .tsx src/"
   },
   "dependencies": {
+    "axios": "^1.2.2",
     "class-validator": "^0.14.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/core/src/clients/AxiosBaseClient.ts
+++ b/packages/core/src/clients/AxiosBaseClient.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
-import config from "config";
+import { getAPIBaseURL } from "../config";
 
-const client = axios.create({ baseURL: config.get("api.host") + "/api" });
+const client = axios.create({ baseURL: getAPIBaseURL() });
 
 export { client as clientInstance };

--- a/packages/core/src/clients/TransactionServiceClient.ts
+++ b/packages/core/src/clients/TransactionServiceClient.ts
@@ -12,21 +12,21 @@ export class TransactionServiceClient extends ServiceClientBase {
       data: data,
       transformRequest: [
         // first, execute the transformer that simplifies the date...
-        (data: AddTransactionDTO) => {
-          const d = data.date;
-
-          const year = d.getFullYear();
-          const month = (d.getMonth() + 1).toString().padStart(2, "0");
-          const day = d.getDate().toString().padStart(2, "0");
-
-          return {
-            ...data,
-            date: `${year}-${month}-${day}`
-          };
-        },
+        (data: AddTransactionDTO) => ({
+          ...data,
+          date: this.simplifyDateString(data.date)
+        }),
 
         // ... and then run all the default transformers after that
         ...(axios.defaults.transformRequest as AxiosRequestTransformer[])
       ]
     });
+
+  /** Converts a Date object to a simplified ISO 8601 date format string in the form "YYYY-MM-DD". */
+  private simplifyDateString = (date: Date) => {
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, "0");
+    const day = date.getDate().toString().padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  };
 }

--- a/packages/core/src/clients/TransactionServiceClient.ts
+++ b/packages/core/src/clients/TransactionServiceClient.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosRequestTransformer } from "axios";
 import { AddTransactionDTO } from "../dto";
 import { ServiceClientBase } from "./ServiceClientBase";
 
@@ -8,14 +9,24 @@ export class TransactionServiceClient extends ServiceClientBase {
     this.sendRequest({
       url: this.createEndPoint(accountID),
       method: "POST",
-      data: { ...data, date: this.simplifyDateString(data.date) }
-    });
+      data: data,
+      transformRequest: [
+        // first, execute the transformer that simplifies the date...
+        (data: AddTransactionDTO) => {
+          const d = data.date;
 
-  /** Converts a Date object to a simplified ISO 8601 date format string in the form "YYYY-MM-DD". */
-  private simplifyDateString = (date: Date) => {
-    const year = date.getFullYear();
-    const month = (date.getMonth() + 1).toString().padStart(2, "0");
-    const day = date.getDate().toString().padStart(2, "0");
-    return `${year}-${month}-${day}`;
-  };
+          const year = d.getFullYear();
+          const month = (d.getMonth() + 1).toString().padStart(2, "0");
+          const day = d.getDate().toString().padStart(2, "0");
+
+          return {
+            ...data,
+            date: `${year}-${month}-${day}`
+          };
+        },
+
+        // ... and then run all the default transformers after that
+        ...(axios.defaults.transformRequest as AxiosRequestTransformer[])
+      ]
+    });
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,0 +1,9 @@
+import jsonData from "./default.json";
+
+const getAPIBaseURL = () => jsonData.api.baseURL;
+
+const getDatabaseConfig = () => jsonData.database;
+
+const getExpressPort = () => jsonData.express.port;
+
+export { getAPIBaseURL, getDatabaseConfig, getExpressPort };

--- a/packages/core/src/config/default.json
+++ b/packages/core/src/config/default.json
@@ -1,4 +1,7 @@
 {
+  "api": {
+    "baseURL": "http://localhost:4000/api"
+  },
   "express": {
     "port": 4000
   },

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,1 @@
+export * from "./config";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./clients";
+export * from "./config";
 export * from "./dto";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,5 +7,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true
   },
+  "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": ["node_modules", "build"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,11 +2518,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/config@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@types/config/-/config-3.3.0.tgz#2b632cb37c639bf8d57054561f5a77d31dcebc1e"
-  integrity sha512-9kZSbl3/X3TVNowLCu5HFQdQmD+4287Om55avknEYkuo6R2dDrsp/EXEHUFvfYeG7m1eJ0WYGj+cbcUIhARJAQ==
-
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -3030,7 +3025,7 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@^1.0.0, axios@^1.2.1:
+axios@^1.0.0, axios@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.2.tgz#72681724c6e6a43a9fea860fc558127dbe32f9f1"
   integrity sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==
@@ -3658,13 +3653,6 @@ config-chain@^1.1.12:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
-
-config@^3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/config/-/config-3.3.8.tgz#14ef7aef22af25877fdaee696ec64d761feb7be0"
-  integrity sha512-rFzF6VESOdp7wAXFlB9IOZI4ouL05g3A03v2eRcTHj2JBQaTNJ40zhAUl5wRbWHqLZ+uqp/7OE0BWWtAVgrong==
-  dependencies:
-    json5 "^2.2.1"
 
 console-control-strings@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Instead of using a custom transformation function to simplify the date when adding a transaction, we are now using a request transformation that takes care of the date transformation directly.

Also had to change the configuration system. node-config is looking for the config directory not where the config.get() call takes places, but where the packages is eventually used (for example, if config.get() is called in core, but that particular core function is used in api, then the config directory is also expected in api). I am now using a simplified version of the same config logic, but the config file only needs to be defined in one place in core.