### PR TITLE
feat: ensure transactions are unique

### DIFF
--- a/apps/api/src/entities/transaction.entity.ts
+++ b/apps/api/src/entities/transaction.entity.ts
@@ -1,5 +1,6 @@
 import { TransactionType } from "@csfin/core";
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import crypto from "node:crypto";
+import { BeforeInsert, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { SecuritiesAccount } from "./account.entity";
 import { Security } from "./security.entity";
 
@@ -9,16 +10,26 @@ class Transaction {
   id!: number;
 
   @Column({ type: "enum", enum: TransactionType })
-  type: TransactionType;
+  type!: TransactionType;
 
+  /** The transaction date is stored as a simplified ISO 8601 date in the form "YYYY-MM-DD". */
   @Column({ type: "date" })
-  date: Date;
-
-  @Column({ type: "decimal", precision: 10, scale: 2 })
-  price: number;
+  date!: string;
 
   @Column({ type: "decimal", precision: 11, scale: 3 })
-  shares: number;
+  shares!: number;
+
+  @Column({ type: "decimal", precision: 10, scale: 2 })
+  price!: number;
+
+  /**
+   * Making sure that transactions are unique and cannot added more than once. Determining uniqueness is done by
+   * calculating a hash over the relevant columns (all of them at the moment, other than the auto-generated ID).
+   *
+   * A hash eas selected instead of a `@Unique` construct since otherwise the complete row would need to be unique.
+   */
+  @Column({ unique: true })
+  hash!: string;
 
   @ManyToOne(() => SecuritiesAccount, (account) => account.transactions)
   account!: SecuritiesAccount;
@@ -26,12 +37,18 @@ class Transaction {
   @ManyToOne(() => Security, (security) => security.transactions)
   security!: Security;
 
-  constructor(type: TransactionType, date: Date, price: number, shares: number) {
-    this.type = type;
-    this.date = date;
-    this.price = price;
-    this.shares = shares;
-  }
+  /**
+   * Hash is calculated and set before we try to insert it into the database.
+   *
+   * Since transactions cannot be updated, we don't need the `@BeforeUpdate()` decorator here.
+   */
+  @BeforeInsert()
+  updateHash = () => {
+    this.hash = crypto
+      .createHash("sha256")
+      .update([this.account.id, this.security.isin, this.type, this.date, this.shares, this.price].join("|"))
+      .digest("hex");
+  };
 }
 
 export { Transaction };

--- a/apps/api/src/services/transactions.service.ts
+++ b/apps/api/src/services/transactions.service.ts
@@ -38,10 +38,13 @@ export class TransactionService {
   addOne = async (accountID: number, data: AddTransactionDTO): Promise<Transaction> =>
     this.accountService.getOneByID(accountID).then(async (account) =>
       this.securityService.getOneByISIN(data.isin).then(async (security) => {
-        const { type, date, price, shares } = data;
-        const transaction = new Transaction(type, date, price, shares);
+        const transaction = new Transaction();
         transaction.account = account;
         transaction.security = security;
+        transaction.type = data.type;
+        transaction.date = data.date;
+        transaction.shares = data.shares;
+        transaction.price = data.price;
         return this.repository.save(transaction);
       })
     );

--- a/apps/dbinit/src/uploadTransactions.ts
+++ b/apps/dbinit/src/uploadTransactions.ts
@@ -1,5 +1,5 @@
 import { parseFromCSV, TransactionData } from "@csfin/codi";
-import { AddTransactionDTO, TransactionServiceClient } from "@csfin/core";
+import { AddTransactionDTO, dateToISO8601, TransactionServiceClient } from "@csfin/core";
 
 /** main() -- IIFE */
 (async () => {
@@ -33,14 +33,11 @@ const processTransactions = (accountID: number, data: TransactionData[]) => {
 };
 
 const transformTransactionData = (t: TransactionData) => {
-  const { isin, type, date, price, shares } = t;
-
   const dto = new AddTransactionDTO();
-  dto.isin = isin;
-  dto.type = type;
-  dto.date = date;
-  dto.price = price;
-  dto.shares = shares;
-
+  dto.type = t.type;
+  dto.isin = t.isin;
+  dto.date = dateToISO8601(t.date);
+  dto.shares = t.shares;
+  dto.price = t.price;
   return dto;
 };

--- a/packages/core/src/clients/TransactionServiceClient.ts
+++ b/packages/core/src/clients/TransactionServiceClient.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosRequestTransformer } from "axios";
 import { AddTransactionDTO } from "../dto";
 import { ServiceClientBase } from "./ServiceClientBase";
 
@@ -9,24 +8,6 @@ export class TransactionServiceClient extends ServiceClientBase {
     this.sendRequest({
       url: this.createEndPoint(accountID),
       method: "POST",
-      data: data,
-      transformRequest: [
-        // first, execute the transformer that simplifies the date...
-        (data: AddTransactionDTO) => ({
-          ...data,
-          date: this.simplifyDateString(data.date)
-        }),
-
-        // ... and then run all the default transformers after that
-        ...(axios.defaults.transformRequest as AxiosRequestTransformer[])
-      ]
+      data: data
     });
-
-  /** Converts a Date object to a simplified ISO 8601 date format string in the form "YYYY-MM-DD". */
-  private simplifyDateString = (date: Date) => {
-    const year = date.getFullYear();
-    const month = (date.getMonth() + 1).toString().padStart(2, "0");
-    const day = date.getDate().toString().padStart(2, "0");
-    return `${year}-${month}-${day}`;
-  };
 }

--- a/packages/core/src/dto/transactions.dto.ts
+++ b/packages/core/src/dto/transactions.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsDefined, IsEnum, IsISIN, IsNumber } from "class-validator";
+import { IsDefined, IsEnum, IsISIN, IsISO8601, IsNumber } from "class-validator";
 
 enum TransactionType {
   BUY = "buy",
@@ -15,8 +15,8 @@ class AddTransactionDTO {
   isin!: string;
 
   @IsDefined()
-  @IsDateString()
-  date!: Date;
+  @IsISO8601()
+  date!: string;
 
   @IsDefined()
   @IsNumber()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./clients";
 export * from "./config";
 export * from "./dto";
+export * from "./util";

--- a/packages/core/src/util/date-utils.ts
+++ b/packages/core/src/util/date-utils.ts
@@ -1,0 +1,8 @@
+const dateToISO8601 = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export { dateToISO8601 };

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./date-utils";


### PR DESCRIPTION
Added a hash column to the transactions table which stores a hash calculated from the other columns prior to insertion. This hash is set to be unique, and therefore duplicate transactions cannot be added to the database.

Also changed the transaction DTO to not use store a Date object any longer. Instead, the ISO 8601 string is generated on the client side and transferred in the DTO.