### PR TITLE
feat: add caching service

### DIFF
--- a/apps/portfolio-api/src/portfolio/portfolio-holding/portfolio-holding.controller.ts
+++ b/apps/portfolio-api/src/portfolio/portfolio-holding/portfolio-holding.controller.ts
@@ -1,8 +1,4 @@
 import {
-  generateHoldingListXirrKey,
-  generateHoldingXirrKey,
-} from "@codescape-financial/core";
-import {
   PortfolioCalculationService,
   PortfolioHoldingService,
 } from "@codescape-financial/portfolio-data-access";
@@ -11,18 +7,13 @@ import {
   XIRRHoldingListResponseDTO,
   XIRRHoldingResponseDTO,
 } from "@codescape-financial/portfolio-data-models";
-import { CACHE_MANAGER } from "@nestjs/cache-manager";
-import { Controller, Get, Inject, Param, Query } from "@nestjs/common";
-import type { Cache } from "cache-manager";
-
-const TTL_MILLISECONDS = 60 * 60 * 1000;
+import { Controller, Get, Param, Query } from "@nestjs/common";
 
 @Controller("portfolios/:portfolioId/holdings")
 export class PortfolioHoldingController {
   constructor(
     private readonly portfolioHoldingService: PortfolioHoldingService,
     private readonly portfolioCalculationService: PortfolioCalculationService,
-    @Inject(CACHE_MANAGER) private cacheManager: Cache, // Inject the Cache Manager
   ) {}
 
   @Get()
@@ -35,27 +26,10 @@ export class PortfolioHoldingController {
     @Param("portfolioId") portfolioId: string,
     @Query() filter: PortfolioViewFilterDTO,
   ): Promise<XIRRHoldingListResponseDTO | null> {
-    const cacheKey = generateHoldingListXirrKey(
+    return this.portfolioCalculationService.calculateXIRRForHoldingListWithCache(
       portfolioId,
       filter.viewType ?? "all",
     );
-
-    // Attempt to retrieve from cache
-    const cachedXIRR =
-      await this.cacheManager.get<XIRRHoldingListResponseDTO>(cacheKey);
-    if (cachedXIRR) {
-      return cachedXIRR;
-    }
-
-    const xirrResult =
-      this.portfolioCalculationService.calculateXIRRForHoldingList(
-        portfolioId,
-        filter.viewType ?? "all",
-      );
-
-    await this.cacheManager.set(cacheKey, xirrResult, TTL_MILLISECONDS);
-
-    return xirrResult;
   }
 
   @Get(":holdingId")
@@ -71,22 +45,9 @@ export class PortfolioHoldingController {
     @Param("portfolioId") portfolioId: string,
     @Param("holdingId") holdingId: string,
   ): Promise<XIRRHoldingResponseDTO | null> {
-    const cacheKey = generateHoldingXirrKey(portfolioId, holdingId);
-
-    // Attempt to retrieve from cache
-    const cachedXIRR =
-      await this.cacheManager.get<XIRRHoldingResponseDTO>(cacheKey);
-    if (cachedXIRR) {
-      return cachedXIRR;
-    }
-
-    const xirrResult = this.portfolioCalculationService.calculateXIRRForHolding(
+    return this.portfolioCalculationService.calculateXIRRForHoldingWithCache(
       portfolioId,
       holdingId,
     );
-
-    await this.cacheManager.set(cacheKey, xirrResult, TTL_MILLISECONDS);
-
-    return xirrResult;
   }
 }

--- a/apps/portfolio-api/src/portfolio/portfolio.controller.ts
+++ b/apps/portfolio-api/src/portfolio/portfolio.controller.ts
@@ -1,4 +1,3 @@
-import { generatePortfolioXirrKey } from "@codescape-financial/core";
 import {
   PortfolioCalculationService,
   PortfolioChartService,
@@ -11,21 +10,16 @@ import {
   UpdatePortfolioDTO,
   XIRRPortfolioResponseDTO,
 } from "@codescape-financial/portfolio-data-models";
-import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import {
   Body,
   Controller,
   Delete,
   Get,
-  Inject,
   Param,
   Post,
   Put,
   Query,
 } from "@nestjs/common";
-import type { Cache } from "cache-manager";
-
-const TTL_MILLISECONDS = 60 * 60 * 1000;
 
 @Controller("portfolios")
 export class PortfolioController {
@@ -33,7 +27,6 @@ export class PortfolioController {
     private readonly portfolioService: PortfolioService,
     private readonly portfolioCalculationService: PortfolioCalculationService,
     private readonly portfolioChartService: PortfolioChartService,
-    @Inject(CACHE_MANAGER) private cacheManager: Cache, // Inject the Cache Manager
   ) {}
 
   @Get()
@@ -69,33 +62,18 @@ export class PortfolioController {
     @Param("id") portfolioId: string,
     @Query() filter: PortfolioViewFilterDTO,
   ): Promise<XIRRPortfolioResponseDTO | null> {
-    const cacheKey = generatePortfolioXirrKey(
+    return this.portfolioCalculationService.calculateXIRRForPortfolioWithCache(
       portfolioId,
       filter.viewType ?? "all",
     );
-
-    // Attempt to retrieve from cache
-    const cachedXIRR =
-      await this.cacheManager.get<XIRRPortfolioResponseDTO>(cacheKey);
-    if (cachedXIRR) {
-      return cachedXIRR;
-    }
-
-    const xirrResult =
-      this.portfolioCalculationService.calculateXIRRForPortfolio(
-        portfolioId,
-        filter.viewType ?? "all",
-      );
-
-    await this.cacheManager.set(cacheKey, xirrResult, TTL_MILLISECONDS);
-
-    return xirrResult;
   }
 
   @Get(":id/allocations")
   async getPortfolioSummary(
     @Param("id") portfolioId: string,
   ): Promise<AllocationResponseDTO> {
-    return this.portfolioChartService.getAllocationChartData(portfolioId);
+    return this.portfolioChartService.getAllocationChartDataWithCache(
+      portfolioId,
+    );
   }
 }

--- a/apps/portfolio-api/tsconfig.app.json
+++ b/apps/portfolio-api/tsconfig.app.json
@@ -24,13 +24,10 @@
   ],
   "references": [
     {
-      "path": "../../libs/core/tsconfig.lib.json"
+      "path": "../../libs/portfolio-data-models/tsconfig.lib.json"
     },
     {
       "path": "../../libs/portfolio-data-access/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/portfolio-data-models/tsconfig.lib.json"
     },
     {
       "path": "../../libs/portfolio-config/tsconfig.lib.json"

--- a/apps/portfolio-api/tsconfig.json
+++ b/apps/portfolio-api/tsconfig.json
@@ -4,13 +4,10 @@
   "include": [],
   "references": [
     {
-      "path": "../../libs/core"
+      "path": "../../libs/portfolio-data-models"
     },
     {
       "path": "../../libs/portfolio-data-access"
-    },
-    {
-      "path": "../../libs/portfolio-data-models"
     },
     {
       "path": "../../libs/portfolio-config"

--- a/libs/core/src/lib/utilities/cache-keys.ts
+++ b/libs/core/src/lib/utilities/cache-keys.ts
@@ -17,3 +17,6 @@ export const generateHoldingXirrKey = (
   portfolioId: string,
   holdingId: string,
 ) => `xirr:${portfolioId}:${holdingId}:${formatNormalizedDate(new Date())}`;
+
+export const generatePortfolioAllocationKey = (portfolioId: string) =>
+  `allocation:${portfolioId}:${formatNormalizedDate(new Date())}`;

--- a/libs/portfolio-data-access/src/lib/portfolio-data-access.module.ts
+++ b/libs/portfolio-data-access/src/lib/portfolio-data-access.module.ts
@@ -9,6 +9,7 @@ import {
   PortfolioOperation,
 } from "./entities";
 import {
+  PortfolioCachingService,
   PortfolioCalculationService,
   PortfolioChartService,
   PortfolioHoldingService,
@@ -33,6 +34,7 @@ import {
     HistoricalDataAccessModule,
   ],
   providers: [
+    PortfolioCachingService,
     PortfolioCalculationService,
     PortfolioChartService,
     PortfolioHoldingService,
@@ -41,6 +43,7 @@ import {
     TaxCalculationService,
   ],
   exports: [
+    PortfolioCachingService,
     PortfolioCalculationService,
     PortfolioChartService,
     PortfolioHoldingService,

--- a/libs/portfolio-data-access/src/lib/services/index.ts
+++ b/libs/portfolio-data-access/src/lib/services/index.ts
@@ -1,3 +1,4 @@
+export { PortfolioCachingService } from "./portfolio-caching.service";
 export { PortfolioCalculationService } from "./portfolio-calculation.service";
 export { PortfolioChartService } from "./portfolio-chart.service";
 export { PortfolioHoldingService } from "./portfolio-holding.service";

--- a/libs/portfolio-data-access/src/lib/services/portfolio-caching.service.ts
+++ b/libs/portfolio-data-access/src/lib/services/portfolio-caching.service.ts
@@ -1,0 +1,61 @@
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import type { Cache } from "cache-manager";
+
+const DEFAULT_TTL_MILLISECONDS = 60 * 60 * 1000;
+
+@Injectable()
+export class PortfolioCachingService {
+  private readonly logger = new Logger(PortfolioCachingService.name);
+
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  /**
+   * Retrieves an item from the cache, or generates it if not found and then caches it.
+   *
+   * @param cacheKey The unique key for the item in the cache.
+   * @param generateObjectFn An async function that generates the object if it's not in the cache.
+   * @param ttlMilliseconds The time-to-live for the cached item in milliseconds. Defaults to DEFAULT_TTL_MILLISECONDS.
+   * @returns A Promise that resolves to the cached or newly generated object.
+   */
+  async getOrCreateAndCache<T>(
+    cacheKey: string,
+    generateObjectFn: () => Promise<T>,
+    ttlMilliseconds: number = DEFAULT_TTL_MILLISECONDS,
+  ): Promise<T> {
+    try {
+      // 1. Attempt to retrieve from cache
+      const cachedObject = await this.cacheManager.get<T>(cacheKey);
+      if (cachedObject) {
+        this.logger.debug(`Cache hit for key: ${cacheKey}`);
+        return cachedObject;
+      }
+
+      this.logger.debug(
+        `Cache miss for key: ${cacheKey}. Generating object...`,
+      );
+
+      // 2. If not in cache, generate the object
+      const newObject = await generateObjectFn();
+
+      // 3. Store the newly generated object in the cache
+      await this.cacheManager.set(cacheKey, newObject, ttlMilliseconds);
+      this.logger.debug(`Object generated and cached for key: ${cacheKey}`);
+
+      return newObject;
+    } catch (error) {
+      if (error instanceof Error) {
+        this.logger.error(
+          `Error during caching operation for key ${cacheKey}:`,
+          error.stack,
+        );
+      }
+
+      // Decide how to handle caching errors:
+      // Option A: Re-throw the error, letting the caller handle it. (Recommended for critical errors)
+      // Option B: Return null/undefined, or fall back to non-cached data. (If caching is optional)
+      // For now, we'll re-throw to ensure the original operation still fails if generation failed.
+      throw error;
+    }
+  }
+}

--- a/libs/portfolio-data-access/src/lib/services/portfolio-calculation.service.ts
+++ b/libs/portfolio-data-access/src/lib/services/portfolio-calculation.service.ts
@@ -1,6 +1,9 @@
 import {
   FLOATING_POINT_TOLERANCE,
   formatNormalizedDate,
+  generateHoldingListXirrKey,
+  generateHoldingXirrKey,
+  generatePortfolioXirrKey,
   getDateObject,
   isEffectivelyZero,
   PortfolioViewType,
@@ -19,8 +22,10 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { In, Repository } from "typeorm";
 import { PortfolioHolding, PortfolioOperation } from "../entities";
 import { CashFlow } from "../types";
+import { PortfolioCachingService } from "./portfolio-caching.service";
 
 const MILLISECONDS_PER_YEAR = 365 * 24 * 3600 * 1000;
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 const MAX_ITERATIONS = 100;
 const INITIAL_LOW_RATE = -0.999999;
 const INITIAL_HIGH_RATE = 10.0;
@@ -36,6 +41,7 @@ export class PortfolioCalculationService {
     @InjectRepository(PortfolioHolding)
     private readonly holdingRepository: Repository<PortfolioHolding>,
     private readonly historicalQuoteService: HistoricalQuoteService,
+    private readonly cachingService: PortfolioCachingService,
   ) {}
 
   // --- Helper for Building Common Holding/Operation Queries ---
@@ -94,6 +100,24 @@ export class PortfolioCalculationService {
   }
 
   // --- calculateXIRRForPortfolio (Refactored) ---
+  async calculateXIRRForPortfolioWithCache(
+    portfolioId: string,
+    viewType: PortfolioViewType,
+  ): Promise<XIRRPortfolioResponseDTO | null> {
+    const cacheKey = generatePortfolioXirrKey(portfolioId, viewType);
+
+    return this.cachingService.getOrCreateAndCache<XIRRPortfolioResponseDTO | null>(
+      cacheKey,
+      async () => {
+        this.logger.verbose(
+          `Generating fresh XIRR data for portfolio ${portfolioId} with viewType ${viewType}`,
+        );
+        return this.calculateXIRRForPortfolio(portfolioId, viewType);
+      },
+      MILLISECONDS_PER_HOUR,
+    );
+  }
+
   async calculateXIRRForPortfolio(
     portfolioId: string,
     viewType: PortfolioViewType,
@@ -153,6 +177,24 @@ export class PortfolioCalculationService {
       date: formatNormalizedDate(calculationDate),
       xirr: this.calculateXIRR(cashflows),
     };
+  }
+
+  async calculateXIRRForHoldingListWithCache(
+    portfolioId: string,
+    viewType: PortfolioViewType,
+  ): Promise<XIRRHoldingListResponseDTO> {
+    const cacheKey = generateHoldingListXirrKey(portfolioId, viewType);
+
+    return this.cachingService.getOrCreateAndCache<XIRRHoldingListResponseDTO>(
+      cacheKey,
+      async () => {
+        this.logger.verbose(
+          `Generating fresh XIRR data for holdings in portfolio ${portfolioId} with viewType ${viewType}`,
+        );
+        return this.calculateXIRRForHoldingList(portfolioId, viewType);
+      },
+      MILLISECONDS_PER_HOUR,
+    );
   }
 
   // --- calculateXIRRForHoldingList (Refactored) ---
@@ -276,6 +318,24 @@ export class PortfolioCalculationService {
     });
 
     return result;
+  }
+
+  async calculateXIRRForHoldingWithCache(
+    portfolioId: string,
+    holdingId: string,
+  ): Promise<XIRRHoldingResponseDTO | null> {
+    const cacheKey = generateHoldingXirrKey(portfolioId, holdingId);
+
+    return this.cachingService.getOrCreateAndCache<XIRRHoldingResponseDTO | null>(
+      cacheKey,
+      async () => {
+        this.logger.verbose(
+          `Generating fresh XIRR data for holding ${holdingId} in portfolio ${portfolioId}`,
+        );
+        return this.calculateXIRRForHolding(portfolioId, holdingId);
+      },
+      MILLISECONDS_PER_HOUR,
+    );
   }
 
   // This method is now only for a SINGLE holding and doesn't need to fetch relations if called

--- a/libs/portfolio-data-access/src/lib/services/portfolio-chart.service.ts
+++ b/libs/portfolio-data-access/src/lib/services/portfolio-chart.service.ts
@@ -1,4 +1,8 @@
-import { formatNormalizedDate, getDateObject } from "@codescape-financial/core";
+import {
+  formatNormalizedDate,
+  generatePortfolioAllocationKey,
+  getDateObject,
+} from "@codescape-financial/core";
 import { HistoricalQuoteService } from "@codescape-financial/historical-data-access";
 import {
   AllocationResponseDTO,
@@ -9,6 +13,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { PortfolioHolding } from "../entities";
+import { PortfolioCachingService } from "./portfolio-caching.service";
 
 @Injectable()
 export class PortfolioChartService {
@@ -18,7 +23,26 @@ export class PortfolioChartService {
     @InjectRepository(PortfolioHolding)
     private readonly holdingRepository: Repository<PortfolioHolding>,
     private readonly historicalQuoteService: HistoricalQuoteService,
+    private readonly cachingService: PortfolioCachingService,
   ) {}
+
+  async getAllocationChartDataWithCache(
+    portfolioId: string,
+  ): Promise<AllocationResponseDTO> {
+    const cacheKey = generatePortfolioAllocationKey(portfolioId);
+    const TTL_MILLISECONDS = 60 * 60 * 1000;
+
+    return this.cachingService.getOrCreateAndCache<AllocationResponseDTO>(
+      cacheKey,
+      async () => {
+        this.logger.verbose(
+          `Generating fresh allocation data for portfolio ${portfolioId}`,
+        );
+        return this.getAllocationChartData(portfolioId);
+      },
+      TTL_MILLISECONDS,
+    );
+  }
 
   async getAllocationChartData(
     portfolioId: string,
@@ -107,15 +131,14 @@ export class PortfolioChartService {
       }),
     );
 
+    assetAllocation.sort((a, b) => a.name.localeCompare(b.name));
+    countryAllocation.sort((a, b) => a.name.localeCompare(b.name));
+
     return {
       portfolioId,
       date: formatNormalizedDate(date),
-      assetAllocation: assetAllocation.sort((a, b) =>
-        a.name.localeCompare(b.name),
-      ),
-      countryAllocation: countryAllocation.sort((a, b) =>
-        a.name.localeCompare(b.name),
-      ),
+      assetAllocation: assetAllocation,
+      countryAllocation: countryAllocation,
     };
   }
 }

--- a/libs/portfolio-data-access/src/lib/services/portfolio-operation.service.ts
+++ b/libs/portfolio-data-access/src/lib/services/portfolio-operation.service.ts
@@ -2,6 +2,7 @@ import {
   FLOATING_POINT_TOLERANCE,
   generateHoldingListXirrKey,
   generateHoldingXirrKey,
+  generatePortfolioAllocationKey,
   generatePortfolioXirrKey,
   isEffectivelyZero,
 } from "@codescape-financial/core";
@@ -530,7 +531,7 @@ export class PortfolioOperationService {
   }
 
   /**
-   * Helper to invalidate relevant XIRR caches.
+   * Helper to invalidate relevant XIRR and asset allocation caches.
    *
    * @param portfolioId The portfolio ID.
    * @param holdingId The holding ID (optional).
@@ -568,6 +569,13 @@ export class PortfolioOperationService {
     await this.cacheManager.del(portfolioActiveCacheKey);
     this.logger.debug(
       `Invalidated portfolio XIRR caches: ${portfolioAllCacheKey}, ${portfolioActiveCacheKey}`,
+    );
+
+    const portfolioAllocationCacheKey =
+      generatePortfolioAllocationKey(portfolioId);
+    await this.cacheManager.del(portfolioAllocationCacheKey);
+    this.logger.debug(
+      `Invalidated portfolio allocation cache: ${portfolioAllocationCacheKey}`,
     );
   }
 }


### PR DESCRIPTION
Now using a generic caching service that can handle cache queries and uses a generator function to potentially create the cache object before storing it.

Both XIRR calculations and allocations by country and asset are now using the caching service.